### PR TITLE
upgrade to java 8, guava 21 and rename deliverables

### DIFF
--- a/driver-core/pom.xml
+++ b/driver-core/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>com.datastax.cassandra</groupId>
     <artifactId>cassandra-driver-parent</artifactId>
-    <version>2.0.9-signalfuse</version>
+    <version>2.0.9-sfx1</version>
   </parent>
   <artifactId>cassandra-driver-core</artifactId>
   <packaging>bundle</packaging>
@@ -40,7 +40,7 @@
         We use an old version of Guava to be compatible with Spark 1.1.
         Check with the spark-cassandra-connector team before upgrading this.
       -->
-      <version>14.0.1</version>
+      <version>21.0</version>
     </dependency>
 
     <dependency>

--- a/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
@@ -1518,7 +1518,7 @@ public class Cluster implements Closeable {
                             connectionFactory.open(host).closeAsync();
                             // Note that we want to do the pool creation on this thread because we want that
                             // when onUp return, the host is ready for querying
-                            onUp(host, MoreExecutors.sameThreadExecutor());
+                            onUp(host, MoreExecutors.newDirectExecutorService());
                             // If one of the connections in onUp failed, it signaled the error and triggerd onDown,
                             // but onDown aborted because this reconnection attempt was in progress (JAVA-577).
                             // Test the state now to check than onUp succeeded (we know it's up-to-date since onUp was

--- a/driver-core/src/main/java/com/datastax/driver/core/HostConnectionPool.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/HostConnectionPool.java
@@ -445,7 +445,7 @@ class HostConnectionPool {
                     if (connection.markForTrash.compareAndSet(false, true))
                         open.decrementAndGet();
                 }
-            }, MoreExecutors.sameThreadExecutor());
+            }, MoreExecutors.directExecutor());
             futures.add(future);
         }
         return futures;

--- a/driver-core/src/main/java/com/datastax/driver/core/SessionManager.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/SessionManager.java
@@ -404,7 +404,7 @@ class SessionManager extends AbstractSession {
         // Note that with well behaved balancing policy (that ignore dead nodes), the removePool call is not necessary
         // since updateCreatedPools should take care of it. But better protect against non well behaving policies.
         removePool(host).force().get();
-        updateCreatedPools(MoreExecutors.sameThreadExecutor());
+        updateCreatedPools(MoreExecutors.newDirectExecutorService());
     }
 
     void onSuspected(Host host) {

--- a/driver-dist/pom.xml
+++ b/driver-dist/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>com.datastax.cassandra</groupId>
     <artifactId>cassandra-driver-parent</artifactId>
-    <version>2.0.9-signalfuse</version>
+    <version>2.0.9-sfx1</version>
   </parent>
   <artifactId>cassandra-driver-dist</artifactId>
 

--- a/driver-dse/pom.xml
+++ b/driver-dse/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>com.datastax.cassandra</groupId>
     <artifactId>cassandra-driver-parent</artifactId>
-    <version>2.0.9-signalfuse</version>
+    <version>2.0.9-sfx1</version>
   </parent>
   <artifactId>cassandra-driver-dse</artifactId>
   <packaging>bundle</packaging>

--- a/driver-examples/pom.xml
+++ b/driver-examples/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>com.datastax.cassandra</groupId>
     <artifactId>cassandra-driver-parent</artifactId>
-    <version>2.0.9-signalfuse</version>
+    <version>2.0.9-sfx1</version>
   </parent>
   <artifactId>cassandra-driver-examples-parent</artifactId>
   <packaging>pom</packaging>

--- a/driver-examples/stress/pom.xml
+++ b/driver-examples/stress/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>com.datastax.cassandra</groupId>
     <artifactId>cassandra-driver-examples-parent</artifactId>
-    <version>2.0.9-signalfuse</version>
+    <version>2.0.9-sfx1</version>
   </parent>
   <artifactId>cassandra-driver-examples-stress</artifactId>
   <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   
   <groupId>com.datastax.cassandra</groupId>
   <artifactId>cassandra-driver-parent</artifactId>
-  <version>2.0.9-signalfuse</version>
+  <version>2.0.9-sfx1</version>
   <packaging>pom</packaging>
   <name>DataStax Java Driver for Apache Cassandra</name>
   <description>A driver for Apache Cassandra 1.2+ that works exclusively with the Cassandra Query Language version 3 (CQL3) and Cassandra's binary protocol.</description>
@@ -74,8 +74,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.1</version>
         <configuration>
-            <source>1.6</source>
-            <target>1.6</target>
+            <source>1.8</source>
+            <target>1.8</target>
             <optimize>true</optimize>
             <showDeprecation>true</showDeprecation>
             <showWarnings>true</showWarnings>


### PR DESCRIPTION
The upgrade to guava 21 requires java 8 (due to usage of `default` in
its interfaces).

Test Plan: Ran unit tests.